### PR TITLE
updating with trimmed newName

### DIFF
--- a/src/components/Add-friends/Friend-list-item.tsx
+++ b/src/components/Add-friends/Friend-list-item.tsx
@@ -44,11 +44,14 @@ const FriendListItem = ({ friend }: IProps) => {
     );
 
     const updateName = () => {
-        if (!newName || newName === "") {
+        const trimmedNewName = newName? newName.trim(): newName
+
+        if (!trimmedNewName || trimmedNewName === "") {
             return alert("Name cannot be empty");
         }
 
-        updateFriendName(friend.id, newName);
+        updateFriendName(friend.id, trimmedNewName);
+        setNewName(trimmedNewName); // change untrimmed newName as well (`   x` to `x`)
         setEditing(false);
     };
 


### PR DESCRIPTION
## problem this pr fixes:
don't allow edited names to be just whitespace or have leading or trailing whitespaces just like Add Friend does

## screenshots(gif)
![whitespace-error](https://user-images.githubusercontent.com/111369805/229771215-5719fd8d-3ad6-4f98-b56a-b7bac50a6a32.gif)
